### PR TITLE
Fix the subdirectory structure

### DIFF
--- a/docs/runners_manual_2021/contacts.md
+++ b/docs/runners_manual_2021/contacts.md
@@ -2,7 +2,7 @@
 layout: default
 title: Contacts
 parent: Runners Manual 2021
-nav_order: 18
+nav_order: 9
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/course/aid_station_table.md
+++ b/docs/runners_manual_2021/course/aid_station_table.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Aid Station Table
-parent: Runners Manual 2021
-nav_order: 8
+parent: Course
+grand_parent: Runners Manual 2021
+nav_order: 3
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/course/aid_stations.md
+++ b/docs/runners_manual_2021/course/aid_stations.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Aid Stations
-parent: Runners Manual 2021
-nav_order: 9
+parent: Course
+grand_parent: Runners Manual 2021
+nav_order: 4
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/course/course.md
+++ b/docs/runners_manual_2021/course/course.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: Crewing and Pacing
+title: Course
 parent: Runners Manual 2021
-nav_order: 11
+has_children: true
+nav_order: 4
 last_modified_date: 2021-05-20
 ---

--- a/docs/runners_manual_2021/course/course.md
+++ b/docs/runners_manual_2021/course/course.md
@@ -6,3 +6,6 @@ has_children: true
 nav_order: 4
 last_modified_date: 2021-05-20
 ---
+## The Hardrock Course
+
+Say something about the course here.

--- a/docs/runners_manual_2021/course/course_description.md
+++ b/docs/runners_manual_2021/course/course_description.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Course Description
-parent: Runners Manual 2021
-nav_order: 7
+parent: Course
+grand_parent: Runners Manual 2021
+nav_order: 2
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/course/course_map.md
+++ b/docs/runners_manual_2021/course/course_map.md
@@ -1,8 +1,9 @@
 ---
 layout: default 
 title: Course Map
-parent: Runners Manual 2021
-nav_order: 6
+parent: Course
+grand_parent: Runners Manual 2021
+nav_order: 1
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/course/solar_lunar.md
+++ b/docs/runners_manual_2021/course/solar_lunar.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Solar and Lunar Data
-parent: Runners Manual 2021
-nav_order: 10
+parent: Course
+grand_parent: Runners Manual 2021
+nav_order: 5
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/covid.md
+++ b/docs/runners_manual_2021/covid.md
@@ -2,7 +2,7 @@
 layout: default
 title: COVID-19 Protocols
 parent: Runners Manual 2021
-nav_order: 2
+nav_order: 1
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/crewing_pacing/crew_driving_directions.md
+++ b/docs/runners_manual_2021/crewing_pacing/crew_driving_directions.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Crew Access Aid Station Driving Directions
-parent: Runners Manual 2021
-nav_order: 13
+parent: Crewing and Pacing
+grand_parent: Runners Manual 2021
+nav_order: 2
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/crewing_pacing/crew_rules.md
+++ b/docs/runners_manual_2021/crewing_pacing/crew_rules.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Crewing and Pacing Rules
-parent: Runners Manual 2021
-nav_order: 12
+parent: Crewing and Pacing
+grand_parent: Runners Manual 2021
+nav_order: 1
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/crewing_pacing/crewing_pacing.md
+++ b/docs/runners_manual_2021/crewing_pacing/crewing_pacing.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: Course
+title: Crewing and Pacing
 parent: Runners Manual 2021
+has_children: true
 nav_order: 5
 last_modified_date: 2021-05-20
 ---

--- a/docs/runners_manual_2021/crewing_pacing/crewing_pacing.md
+++ b/docs/runners_manual_2021/crewing_pacing/crewing_pacing.md
@@ -6,3 +6,6 @@ has_children: true
 nav_order: 5
 last_modified_date: 2021-05-20
 ---
+## Crewing and Pacing
+
+Talk about crewing and pacing generally here.

--- a/docs/runners_manual_2021/crewing_pacing/drop_bags.md
+++ b/docs/runners_manual_2021/crewing_pacing/drop_bags.md
@@ -1,8 +1,9 @@
 ---
 layout: default
 title: Drop Bags
-parent: Runners Manual 2021
-nav_order: 14
+parent: Crewing and Pacing
+grand_parent: Runners Manual 2021
+nav_order: 3
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/partners.md
+++ b/docs/runners_manual_2021/partners.md
@@ -2,7 +2,7 @@
 layout: default
 title: Partners
 parent: Runners Manual 2021
-nav_order: 19
+nav_order: 10
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/rules.md
+++ b/docs/runners_manual_2021/rules.md
@@ -2,7 +2,7 @@
 layout: default
 title: Rules
 parent: Runners Manual 2021
-nav_order: 3
+nav_order: 2
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/safety.md
+++ b/docs/runners_manual_2021/safety.md
@@ -2,7 +2,7 @@
 layout: default
 title: Safety
 parent: Runners Manual 2021
-nav_order: 15
+nav_order: 6
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/schedule.md
+++ b/docs/runners_manual_2021/schedule.md
@@ -2,7 +2,7 @@
 layout: default
 title: Schedule
 parent: Runners Manual 2021
-nav_order: 4
+nav_order: 3
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/scholarship.md
+++ b/docs/runners_manual_2021/scholarship.md
@@ -2,7 +2,7 @@
 layout: default
 title: Joel Zucker Memorial Scholarship
 parent: Runners Manual 2021
-nav_order: 17
+nav_order: 8
 last_modified_date: 2021-05-20
 ---
 

--- a/docs/runners_manual_2021/value_statements.md
+++ b/docs/runners_manual_2021/value_statements.md
@@ -2,7 +2,7 @@
 layout: default
 title: Value Statements
 parent: Runners Manual 2021
-nav_order: 16
+nav_order: 7
 last_modified_date: 2021-05-20
 ---
 

--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@ layout: title_page
 title: Welcome to Hardrock!
 subtitle: Documentation and Manuals
 identifier: Index Page
+nav_exclude: true
 description: "Documentation and manuals for the Hardrock Hundred Endurance Run"
 ---
 

--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 ---
 layout: title_page
-title: Hardrock Runners Manual 2021
-subtitle: July 16-18, 2021
-identifier: Runners Manual 2021
-nav_order: 1
-description: "The official Runners Manual for the 2021 Hardrock Hundred Endurance Run"
+title: Welcome to Hardrock!
+subtitle: Documentation and Manuals
+identifier: Index Page
+description: "Documentation and manuals for the Hardrock Hundred Endurance Run"
 ---
 
-{: .fs-9 }
+This is the home page for all documentation and manuals for the Hardrock Hundred Endurance Run. 
+Click on an item on the menu to get started.


### PR DESCRIPTION
The manual is currently arranged with all files in a flat directory structure. 

This PR moves course-related pages under a "Course" subheading and moves crewing/pacing-related pages under a "Crewing and Pacing" subheading.